### PR TITLE
Fix: Handle empty inputs in backend tests and API

### DIFF
--- a/backend-python/app/routers/classify.py
+++ b/backend-python/app/routers/classify.py
@@ -1,6 +1,6 @@
 """Router for text classification."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from app.classifier import classify_text
 
@@ -28,6 +28,8 @@ async def classify_text_endpoint(request: ClassificationRequest):
     Endpoint to classify text.
     Receives text and returns its classification label and score.
     """
+    if not request.text or request.text.isspace():
+        raise HTTPException(status_code=400, detail="Input text cannot be empty.")
     # classify_text is expected to return a dict like {'label': 'LABEL_X', 'score': 0.99},
     # as it's assumed to return result[0] from a Hugging Face pipeline.
     classification_result = classify_text(request.text)

--- a/backend-python/app/routers/summarize.py
+++ b/backend-python/app/routers/summarize.py
@@ -1,6 +1,6 @@
 """API router for text summarization."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
 
@@ -30,6 +30,8 @@ async def summarize_text_endpoint(request: SummarizationRequest):
     """
     Summarizes the input text using a preloaded model.
     """
+    if not request.text or request.text.isspace():
+        raise HTTPException(status_code=400, detail="Input text cannot be empty.")
     inputs = tokenizer.encode(
         "summarize: " + request.text,
         return_tensors="pt",

--- a/backend-python/tests/test_api.py
+++ b/backend-python/tests/test_api.py
@@ -42,8 +42,7 @@ def test_summarization_empty():
     # It might process it and return a very short/empty summary (200)
     # Or it might be a server error if not handled (500)
     # For now, asserting 200 as per previous test runs, but this needs clarification
-    assert response.status_code == 200  # Adjusted from 400, to be verified
-    assert "summary" in response.json()  # Ensuring this line is clean
+    assert response.status_code == 400  # Adjusted from 400, to be verified
 
 
 
@@ -51,9 +50,7 @@ def test_classification_empty():
     """Test the classification endpoint with empty text."""
     response = client.post("/api/classify", json={"text": ""})
     # Similar to summarization, actual behavior for empty string needs verification
-    assert response.status_code == 200  # Adjusted from 400, to be verified
-    assert "label" in response.json()
-    assert "score" in response.json()
+    assert response.status_code == 400  # Adjusted from 400, to be verified
 
 
 def test_summarization_missing():


### PR DESCRIPTION
The test-python-backend CI job was failing due to assertions expecting a 200 OK for empty string inputs in the summarization and classification API endpoints.

This commit updates the following:
- `test_api.py`: I modified `test_summarization_empty` and `test_classification_empty` to expect a 400 Bad Request status code when an empty or whitespace-only string is provided. I removed assertions for specific fields (e.g., "summary", "label") in the JSON response for these error cases, as they would not be present.
- `app/routers/summarize.py`: I added input validation to the `summarize_text_endpoint` to check if the input text is empty or consists only of whitespace. If so, it now raises an HTTPException with a 400 status code.
- `app/routers/classify.py`: I added similar input validation to the `classify_text_endpoint`. It now also raises an HTTPException with a 400 status code for empty or whitespace-only inputs.

With these changes, the API now correctly returns a 400 error for invalid empty inputs, and the tests accurately reflect this expected behavior. All Python backend tests now pass.