### PR TITLE
Fix: Correct CI build-test failures and import errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,14 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install Python Dependencies
       working-directory: backend-python
       run: |
         pip install -r requirements.txt
-        python -m unittest discover -s tests
+        pip install pytest # Added pytest here
+        pytest tests # Changed to pytest tests
 
     - name: Set up Java 17
       uses: actions/setup-java@v3
@@ -51,4 +52,5 @@ jobs:
       working-directory: frontend-react
       run: |
         npm install
+        npm test
         npm run build

--- a/backend-python/app/main.py
+++ b/backend-python/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
-from model_utils import summarize_text, classify_text
+from .summarizer import summarize_text
+from .classifier import classify_text
 
 app = FastAPI()
 

--- a/backend-python/tests/test_api.py
+++ b/backend-python/tests/test_api.py
@@ -30,9 +30,7 @@ def test_classification():
     response = client.post("/api/classify", json={"text": text_to_classify})
     assert response.status_code == 200
     # Assuming the service returns a label, actual key might vary
-    # For now, checking if the response is a non-empty list as per current classify_text
-    assert response.json()  # Check if it's a valid JSON response
-    # assert "label" in response.json() # Or more specific key if known
+    assert "label" in response.json() # Or more specific key if known
 
 
 def test_summarization_empty():
@@ -68,16 +66,6 @@ def test_summarize_non_string_input():
     """Test summarization with non-string input."""
     response = client.post("/api/summarize", json={"text": 12345})
     assert response.status_code == 422  # Unprocessable Entity
-
-def test_summarization_success():
-    response = client.post("/api/summarize", json={"text": "আন্তর্জাতিক বাজারে তেলের দাম হঠাৎ কমে গেছে।"})
-    assert response.status_code == 200
-    assert "summary" in response.json()
-
-def test_classification_success():
-    response = client.post("/api/classify", json={"text": "বাংলাদেশের অর্থনীতি কৃষিনির্ভর।"})
-    assert response.status_code == 200
-    assert "label" in response.json()
 
 def test_summarization_error_short_text():
     response = client.post("/api/summarize", json={"text": "হেলো"})


### PR DESCRIPTION
- Updated Python tests in `test.yml` to use pytest instead of unittest.
- Refactored Python API tests in `test_api.py` to remove duplicates and standardize assertions.
- Added execution of frontend tests (`npm test`) to the `test.yml` workflow.
- Ensured Python version is explicitly '3.10' (string) in CI workflows.
- Corrected imports in `backend-python/app/main.py` to resolve `ModuleNotFoundError` for summarizer and classifier functions.