### PR TITLE
Fix: Correct ruff command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           pip install ruff pytest
 
       - name: Lint (ruff)
-        run: ruff app tests
+        run: ruff check app tests
 
       - name: Run Tests
         run: pytest tests


### PR DESCRIPTION
The previous command `ruff app tests` was incorrect and caused the CI pipeline to fail. This commit updates the command to `ruff check app tests`, which is the correct way to invoke ruff for checking files and directories.